### PR TITLE
rdio, sinatra, and thin were called out as development dependencies for some reason.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,12 +7,13 @@ source "http://rubygems.org"
 # Include everything needed to run rake, tests, features, etc.
 gem 'robut'
 group :development do
-  gem 'thin'
   gem "rspec", "~> 2.3.0"
   gem "bundler", "~> 1.0.0"
   gem "jeweler", "~> 1.6.4"
   gem "rcov", ">= 0"
-  gem 'rdio', '0.0.91' # .92 is horked
-  gem 'sinatra'
   gem 'highline'
 end
+
+gem 'rdio', '0.0.91' # .92 is horked
+gem 'sinatra'
+gem 'thin'


### PR DESCRIPTION
These should be called out as regular dependencies, otherwise bundler won't be able to get the dependency tree right when the gem is installed.
